### PR TITLE
Fr/1 trap implementation v2 v3

### DIFF
--- a/examples/v3arch/asyncio/agent/trap-receive-v3.py
+++ b/examples/v3arch/asyncio/agent/trap-receive-v3.py
@@ -1,11 +1,12 @@
 
 from pysnmp.hlapi.v3arch.asyncio.TrapListener import *
-from pysnmp.hlapi.v3arch.asyncore import *
+from pysnmp.hlapi.v3arch.asyncio import *
 from pysnmp.smi import view
 from pysnmp.proto.rfc1902 import ObjectName
 import time
 from pysnmp.hlapi.v3arch.auth import *
 from pysnmp.entity.config import *
+import asyncio
 
 snmpengine = SnmpEngine()
 community_string = 'public'
@@ -14,17 +15,17 @@ snmpengine1 = SnmpEngine()
 
 authentication_method = ['no-auth-no-priv', 'auth-no-priv', 'auth-priv']
 
-authentication_protocol = ['md5', 'sha', 'sha-224', 'sha-256', 'sha-384', 'sha-512']
+authentication_protocol = ['sha-512', 'md5', 'sha', 'sha-224', 'sha-256', 'sha-384']
 
-auth_keyword_config = [USM_AUTH_HMAC96_MD5, USM_AUTH_HMAC96_SHA, USM_AUTH_HMAC128_SHA224,
-USM_AUTH_HMAC192_SHA256, USM_AUTH_HMAC256_SHA384,USM_AUTH_HMAC384_SHA512]
+auth_keyword_config = [USM_AUTH_HMAC384_SHA512,USM_AUTH_HMAC96_MD5, USM_AUTH_HMAC96_SHA, USM_AUTH_HMAC128_SHA224,
+USM_AUTH_HMAC192_SHA256, USM_AUTH_HMAC256_SHA384]
 
 
 authentication_passphrase = 'testsha234'
 
-privacy_protocol = ['aes-128','aes-256','aes-192','aes-192-blue-menthal','aes-256-blue-menthal','des-3','des']
+privacy_protocol = ['aes-128','aes-192-blue-menthal','aes-256-blue-menthal','des-3','des']
 
-privacy_config = [USM_PRIV_CFB128_AES, USM_PRIV_CFB256_AES, USM_PRIV_CFB192_AES,
+privacy_config = [USM_PRIV_CFB128_AES,
 USM_PRIV_CFB192_AES_BLUMENTHAL, USM_PRIV_CFB256_AES_BLUMENTHAL, USM_PRIV_CBC168_3DES,
 USM_PRIV_CBC56_DES]
 
@@ -35,34 +36,30 @@ server_address = 'localhost'
 n_var1 = NotificationType(ObjectIdentity('SNMPv2-MIB', 'coldStart'))
 n_var2 = NotificationType(ObjectIdentity('SNMPv2-MIB', 'warmStart'))
 
-server_port = 1015
+server_port = 1700
 
 def send_notifications(snmpengine, auth_details, server_address, server_port, notification_var):
-    iterator = sendNotification(
-        snmpengine,
+    iterator = asyncio.run(sendNotification(
+        SnmpEngine(),
         auth_details,
         UdpTransportTarget((server_address, server_port)),
         ContextData(),
         'trap',
-        notification_var, lookupMib=True)
-
-    snmpengine.transportDispatcher.runDispatcher()
+        notification_var, lookupMib=True))
     
-
-
-
+    
 
 
 check_printed_output = [
     'SNMPv2-MIB::sysUpTime.0 = 0',
     'SNMPv2-MIB::snmpTrapOID.0 = SNMPv2-MIB::coldStart']
 
-time.sleep(3)
+
 
 
 
 def check_v3_traps(user_name = 'testuser', auth_protocol = None, priv_protocol = None, auth_proto_config = None, 
-priv_proto_config = None, auth_proto_method = None):
+priv_proto_config = None, auth_proto_method = None, test_port = 1700, test_addresss = 'localhost'):
 
     if auth_protocol is None:
         auth_pass = None
@@ -73,54 +70,59 @@ priv_proto_config = None, auth_proto_method = None):
         priv_pass = None
     else:
         priv_pass = privacy_passphrase
-
+    
     auth_detailsv2 = UsmUserData(userName=user_name, 
     authKey=auth_pass, privKey=priv_pass, authProtocol=auth_proto_config,
     privProtocol=priv_proto_config)
-    
+   
     trap_listener = start_listener(
-    snmpengine1, server_address=server_address, server_port=server_port,
+    snmpEngine=SnmpEngine(), server_address=test_addresss, server_port=test_port,
     protocol='v3', authentication_method = auth_proto_method, auth_protocol=auth_protocol,
     auth_passphrase=auth_pass ,priv_protocol=priv_protocol, priv_passphrase=priv_pass
 )
 
-    time.sleep(10)
     
-    send_notifications(snmpengine=snmpengine, auth_details=auth_detailsv2, server_address=server_address,
-    server_port=server_port, notification_var=n_var1)
+    send_notifications(snmpengine=snmpengine, auth_details=auth_detailsv2, server_address=test_addresss,
+    server_port=test_port, notification_var=n_var1)
     
-    time.sleep(5)
+    time.sleep(2)
 
     trap_list = trap_listener.getTrapList()
-
-
-    time.sleep(5)
+    print("length of trap list %s"%len(trap_list))
 
     assert len(trap_list) >= 1
-    print(trap_list)
+    
 
     for each_trap in trap_list:
 
         assert [each_entry['fully_printed'] for each_entry in each_trap['varBindList']] == check_printed_output
 
 
-
-    time.sleep(5)
-
     trap_listener.stop_listener()
 
-    time.sleep(10)
+
+for each_port in [1700,  2500, 3500]:
+    auth_proto_method = 'no-auth-no-priv'
     
-
-
-
-auth_proto_method = 'auth-priv'
-
-
-for (each_auth_proto, each_auth_proto_config) in zip(authentication_protocol, auth_keyword_config):
-    for (each_priv_proto, each_priv_proto_config) in zip(privacy_protocol, privacy_config):
-
+    check_v3_traps(auth_protocol=None, priv_protocol=None,
+            auth_proto_config=None, priv_proto_config=None,
+            auth_proto_method=auth_proto_method)
+        
+    auth_proto_method = 'auth-no-priv'
     
-        check_v3_traps(auth_protocol=each_auth_proto, priv_protocol=each_priv_proto,
-        auth_proto_config=each_auth_proto_config, priv_proto_config=each_priv_proto_config,
-        auth_proto_method=auth_proto_method)
+    for (each_auth_proto, each_auth_proto_config) in zip(authentication_protocol, auth_keyword_config):
+        check_v3_traps(auth_protocol=each_auth_proto, priv_protocol=None,
+                auth_proto_config=each_auth_proto_config, priv_proto_config=None,
+                auth_proto_method=auth_proto_method)
+    
+    
+    auth_proto_method = 'auth-priv'
+    
+    
+    for (each_auth_proto, each_auth_proto_config) in zip(authentication_protocol, auth_keyword_config):
+        for (each_priv_proto, each_priv_proto_config) in zip(privacy_protocol, privacy_config):
+    
+        
+            check_v3_traps(auth_protocol=each_auth_proto, priv_protocol=each_priv_proto,
+            auth_proto_config=each_auth_proto_config, priv_proto_config=each_priv_proto_config,
+            auth_proto_method=auth_proto_method)

--- a/pysnmp/hlapi/v3arch/asyncio/ntfrcv.py
+++ b/pysnmp/hlapi/v3arch/asyncio/ntfrcv.py
@@ -47,7 +47,12 @@ class TrapListener():
         self.privProtocol = priv_protocol
         self.authPassphrase = auth_passphrase
         self.privPassphrase = priv_passphrase
-        self.main_loop = asyncio.get_event_loop()
+        try:
+            self.main_loop = asyncio.get_event_loop()
+        except RuntimeError:
+            asyncio.set_event_loop(asyncio.new_event_loop())
+            self.main_loop = asyncio.get_event_loop()
+        
         self.execution_future = None
         self.thread_for_executing = futures.ThreadPoolExecutor(max_workers=2)
         self.cbSec = cbSec

--- a/pysnmp/hlapi/v3arch/asyncio/ntfrcv.py
+++ b/pysnmp/hlapi/v3arch/asyncio/ntfrcv.py
@@ -311,6 +311,7 @@ class TrapListener():
         self.transporter.runDispatcher()
     
     def getTrapList(self):
+        time.sleep(1)
         return self.trap_in_session
     
     def start_listener(self, server_address, server_port, timeout):

--- a/pysnmp/smi/mibs/PYSNMP-USM-MIB.py
+++ b/pysnmp/smi/mibs/PYSNMP-USM-MIB.py
@@ -373,7 +373,7 @@ Information about a particular USM user credentials.
 class _PysnmpUsmKeyAuthLocalized_Type(OctetString):
     subtypeSpec = OctetString.subtypeSpec
     subtypeSpec += ConstraintsUnion(
-        ValueSizeConstraint(8, 32),
+        ValueSizeConstraint(8, 64),
     )
     defaultHexValue = '0000000000000000'
 
@@ -419,7 +419,7 @@ User's localized key used for encryption.
 class _PysnmpUsmKeyAuth_Type(OctetString):
     subtypeSpec = OctetString.subtypeSpec
     subtypeSpec += ConstraintsUnion(
-        ValueSizeConstraint(8, 32),
+        ValueSizeConstraint(8, 64),
     )
     defaultHexValue = '0000000000000000'
 

--- a/pysnmp/smi/mibs/PYSNMP-USM-MIB.py
+++ b/pysnmp/smi/mibs/PYSNMP-USM-MIB.py
@@ -396,7 +396,7 @@ User's localized key used for authentication.
 class _PysnmpUsmKeyPrivLocalized_Type(OctetString):
     subtypeSpec = OctetString.subtypeSpec
     subtypeSpec += ConstraintsUnion(
-        ValueSizeConstraint(8, 32),
+        ValueSizeConstraint(8, 256),
     )
     defaultHexValue = '0000000000000000'
 
@@ -442,7 +442,7 @@ User's non-localized key used for authentication.
 class _PysnmpUsmKeyPriv_Type(OctetString):
     subtypeSpec = OctetString.subtypeSpec
     subtypeSpec += ConstraintsUnion(
-        ValueSizeConstraint(8, 32),
+        ValueSizeConstraint(8, 256),
     )
     defaultHexValue = '0000000000000000'
 


### PR DESCRIPTION
### Changes

1.Changed the test case. It seems AES-blue-menthal is used by net-snmp. So edited the test case to include only that.
2.Modified the ValueConstraints so it reflects octet size of auth sha-512 and aes-256.
3.Modified the trap listener so it can be restarted once done..
